### PR TITLE
Amended documentation with respect to testing

### DIFF
--- a/docs/source/developer/testing.rst
+++ b/docs/source/developer/testing.rst
@@ -1,7 +1,13 @@
 Testing
 =======
 
-Testing is done with the `unittest` framework. In the parent directory,
+Testing is done with the `unittest` framework. In the parent directory, build the source files
+
+.. code-block:: bash
+
+   $ python setup.py build_src build_ext --inplace
+
+and run the testing utility
 
 .. code-block:: bash
 


### PR DESCRIPTION
The documentation now mentions how to build the source before running tests via `nosetests`.