### PR TITLE
Added fortran compiler switch (-fallow-argument-mismatch).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,9 @@ if not os.environ.get('READTHEDOCS', None) == 'True':
                         "nufft2df90.f",
                         "nufft3df90.f"]))
     sources += [os.path.join("nufft", "nufft.pyf")]
-    extensions = [Extension("nufft._nufft", sources=sources)]
+    extensions = [Extension("nufft._nufft",
+                            sources=sources,
+                            extra_f77_compile_args=["-fallow-argument-mismatch"])]
 
 setup(
     name="nufft",


### PR DESCRIPTION
By invoking this switch, error messages as of "Error: Type mismatch in argument 'ifac' at (1); passed REAL(8) to INTEGER(4)" are changed into warnings.

Functions work fine for me, but there's still one test failing, but obviously not due to the compiler switch. (Tested on Windows 11, MSVC 2019, 64bit)
```
================================================= test session starts ================================================= platform win32 -- Python 3.9.13, pytest-8.1.1, pluggy-1.4.0 rootdir: D:\git\python-nufft
plugins: anyio-4.3.0, dash-2.16.1, hypothesis-6.99.1, cov-4.1.0, time-machine-2.14.0 collected 42 items

test_nufft1d.py .....F                                                                                           [ 14%]
test_nufft1d_dft.py ........                                                                                     [ 33%]
test_nufft2d.py ..............                                                                                   [ 66%]
test_nufft3d.py ..............                                                                                   [100%]

====================================================== FAILURES ======================================================= _____________________________________________ NUFFT1DTestCase.test_type_3 _____________________________________________

self = <test_nufft1d.NUFFT1DTestCase testMethod=test_type_3>

    def test_type_3(self):
        """Is the 1D type 3 correct?"""
        for eps in [1e-2, 1e-5, 1e-10, 1e-12]:
>           self._type_3(eps)

test_nufft1d.py:120:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ test_nufft1d.py:71: in _type_3
    self.assertTrue(_error(p1, p2) < eps,
E   AssertionError: False is not true : Type 3: Discrepancy between direct and fft function
=============================================== short test summary info ===============================================
FAILED test_nufft1d.py::NUFFT1DTestCase::test_type_3 - AssertionError: False is not true : Type 3: Discrepancy between direct and fft function
============================================ 1 failed, 41 passed in 11.11s ============================================
```